### PR TITLE
Discovery populate

### DIFF
--- a/pkg/commands/status_discovery.go
+++ b/pkg/commands/status_discovery.go
@@ -26,6 +26,7 @@ import (
 	"k8s.io/kops/upup/pkg/fi/cloudup/awstasks"
 	"k8s.io/kops/upup/pkg/fi/cloudup/awsup"
 	"k8s.io/kops/upup/pkg/fi/cloudup/gce"
+	"k8s.io/kops/upup/pkg/fi/cloudup/openstack"
 )
 
 // CloudDiscoveryStatusStore implements status.Store by inspecting cloud objects.
@@ -66,6 +67,10 @@ func (s *CloudDiscoveryStatusStore) GetApiIngressStatus(cluster *kops.Cluster) (
 		}
 
 		return ingresses, nil
+	}
+
+	if osCloud, ok := cloud.(openstack.OpenstackCloud); ok {
+		return osCloud.GetApiIngressStatus(cluster)
 	}
 
 	return nil, fmt.Errorf("API Ingress Status not implemented for %T", cloud)

--- a/upup/pkg/fi/cloudup/populate_instancegroup_spec.go
+++ b/upup/pkg/fi/cloudup/populate_instancegroup_spec.go
@@ -26,6 +26,7 @@ import (
 	"k8s.io/kops/pkg/apis/kops/validation"
 	"k8s.io/kops/upup/pkg/fi"
 	"k8s.io/kops/upup/pkg/fi/cloudup/awsup"
+	"k8s.io/kops/upup/pkg/fi/cloudup/openstack"
 	"k8s.io/kops/upup/pkg/fi/utils"
 )
 
@@ -201,6 +202,19 @@ func defaultMachineType(cluster *kops.Cluster, ig *kops.InstanceGroup) (string, 
 		case kops.InstanceGroupRoleBastion:
 			return defaultBastionMachineTypeVSphere, nil
 		}
+
+	case kops.CloudProviderOpenstack:
+		cloud, err := BuildCloud(cluster)
+		if err != nil {
+			return "", fmt.Errorf("error building cloud for Openstack cluster: %v", err)
+		}
+
+		instanceType, err := cloud.(openstack.OpenstackCloud).DefaultInstanceType(cluster, ig)
+		if err != nil {
+			return "", fmt.Errorf("error finding default machine type: %v", err)
+		}
+		return instanceType, nil
+
 	}
 
 	glog.V(2).Infof("Cannot set default MachineType for CloudProvider=%q, Role=%q", cluster.Spec.CloudProvider, ig.Spec.Role)


### PR DESCRIPTION
Enable kops the ability to figure out what the address or host to populate in the kube/config is for the api server.
Determine the default flavours to use for master/node/bastion.  Bastion cannot be specified in Openstack so its required for anything to work.